### PR TITLE
Configure GitHub to recognize Helm chart files as Rust (#5)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+helm-chart/** linguist-language=Rust


### PR DESCRIPTION
Closes #5 