### PR TITLE
Switch to nginx:latest image with standard web server ports (#10)

### DIFF
--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -16,10 +16,13 @@ spec:
     spec:
       containers:
         - name: kube-example
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: nginx:latest
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - containerPort: 8080
+            - containerPort: 80
+              name: http
+            - containerPort: 443
+              name: https
           volumeMounts:
             - name: certs
               mountPath: /etc/nginx/certs


### PR DESCRIPTION
This PR updates the deployment to use a standard nginx web server configuration.

Changes:
- Switches to `nginx:latest` image
- Configures standard ports `80`/`443` instead of `8080`

Testing:
✅ Existing TLS certificates used for HTTPS support
✅ Deployment verified with 2 replicas running

Closes #10 